### PR TITLE
[fix] binary file name should be usteerd

### DIFF
--- a/openwrt/usteer/Makefile
+++ b/openwrt/usteer/Makefile
@@ -31,7 +31,7 @@ endef
 define Package/usteer/install
 	$(INSTALL_DIR) $(1)/sbin $(1)/etc/init.d $(1)/etc/config
 	$(CP) ./files/* $(1)/
-	$(CP) $(PKG_BUILD_DIR)/usteer $(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/usteerd $(1)/sbin/
 endef
 
 $(eval $(call BuildPackage,usteer))


### PR DESCRIPTION
the binary file name to be copied while install it in the OpenWrt package should be usteerd not usteer